### PR TITLE
Use https in gatherLinks when detected

### DIFF
--- a/src/Stolz/Assets/Manager.php
+++ b/src/Stolz/Assets/Manager.php
@@ -424,7 +424,9 @@ class Manager
 			if($this->isRemoteLink($link))
 			{
 				if('//' === substr($link, 0, 2))
-					$link = 'http:' . $link;
+					(isset($_SERVER["HTTPS"]) && !empty($_SERVER["HTTPS"]) && $_SERVER["HTTPS"] !== 'off') ?
+                        			$link = 'https:' . $link :
+                        			$link = 'http:' . $link;
 			}
 			else
 			{


### PR DESCRIPTION
Uses https to fetch protocol agnostic external resources in gatherLinks when request is made over https. Fixes issue with Google Fonts. Might still give problems when app is reachable over both http and https.
