### PR TITLE
Added a way to set a custom link wrapper

### DIFF
--- a/src/Stolz/Assets/Manager.php
+++ b/src/Stolz/Assets/Manager.php
@@ -69,7 +69,10 @@ class Manager
 	protected $fetch_command;
 
 	/**
-	 * Closure used to wrap output when serve assets.
+	 * Closure used to wrap output when serving assets.
+	 *
+	 * The closure will recieve as the only parameter a string with the URL of the asset and
+	 * it should return a way to get the full URL as a string
 	 * @var Closure
 	 */
 	protected $wrap_command;


### PR DESCRIPTION
This fixes problem #17 but allows it to be a lot more useful and support not just laravel.

Example config for laravel would be:

``` php
$config = array(
    ...
    'wrap_command' => function($link) {
        return asset($link);
    }
    ...
);
```
