### PR TITLE
Added support for nesting collection arrays with paths.

### DIFF
--- a/src/Stolz/Assets/Manager.php
+++ b/src/Stolz/Assets/Manager.php
@@ -192,17 +192,26 @@ class Manager
 	 *
 	 * It automatically detects the asset type (JavaScript, CSS or collection).
 	 * You may add more than one asset passing an array as argument.
+	 * You may add a path to an array as a way of reducing repetition.
 	 *
 	 * @param  mixed   $asset
+	 * @param  mixed   $path
 	 * @return Manager
 	 */
-	public function add($asset)
+	public function add($asset, $path = "")
 	{
 		// More than one asset
 		if(is_array($asset))
 		{
+			// Append path to existing path variable
+			if(isset($asset['path']))
+			{
+				$path .= "$asset[path]/";
+				unset($asset['path']);
+			}
+
 			foreach($asset as $a)
-				$this->add($a);
+				$this->add($a, $path);
 		}
 		// Collection
 		elseif(isset($this->collections[$asset]))
@@ -211,6 +220,8 @@ class Manager
 		}
 		else
 		{
+			// Add path to asset
+			$asset = $path . $asset;
 			// JavaScript or CSS
 			$info = pathinfo($asset);
 			if(isset($info['extension']))


### PR DESCRIPTION
This change allows users to represent their folder structure better when creating collections. The alternative is to add the folder structure in as the array key, however this method requires minimal structural changes to the code, and is fully backwards compatible.

Example structure would be:

```
array(
    'angular' => array(
        'path' => 'views/worker/home',
            'app.js',
            'factories' => array(
                'path' => 'factories',
                'Address.js',
            ),
            'directives' => array(
                'path' => 'directives',
                'signature.js',
            ),
            'controllers' => array(
                'path' => 'controllers',
                'JobController.js',
            ),
    ),
)
```

This becomes quite useful if you have a large number of files in each folder.
