### PR TITLE
Allow for empty css and js subdirectory

### DIFF
--- a/src/Stolz/Assets/Manager.php
+++ b/src/Stolz/Assets/Manager.php
@@ -502,11 +502,11 @@ class Manager
 	 * Build Absolute Path
 	 * 
 	 * @param type $subdirectory 
-	 * @param type $file 
+	 * @param type $filename 
 	 * 
 	 * @return string
 	 */
-	protected function buildAbsolutePath($subdirectory, $file) 
+	protected function buildAbsolutePath($subdirectory, $filename) 
 	{
 
 		//initialize
@@ -519,7 +519,7 @@ class Manager
 		}
 		
 		//append file
-		$absolute_path .= $this->pipeline_dir . DIRECTORY_SEPARATOR . $file;
+		$absolute_path .= $this->pipeline_dir . DIRECTORY_SEPARATOR . $filename;
 
 		return $absolute_path;
 	}

--- a/src/Stolz/Assets/Manager.php
+++ b/src/Stolz/Assets/Manager.php
@@ -465,7 +465,7 @@ class Manager
 		// Generate paths
 		$filename = md5(implode($assets)) . $extension;
 		$relative_path = "$subdirectory/{$this->pipeline_dir}/$filename";
-		$absolute_path = $this->public_dir . DIRECTORY_SEPARATOR . $subdirectory . DIRECTORY_SEPARATOR . $this->pipeline_dir . DIRECTORY_SEPARATOR . $filename;
+		$absolute_path = $this->buildAbsolutePath($subdirectory, $filename);
 
 		// If pipeline already exist return it
 		if(file_exists($absolute_path))
@@ -496,6 +496,32 @@ class Manager
 			$this->notify_command->__invoke($filename, $relative_path, $absolute_path, $assets, $gzip);
 
 		return $relative_path;
+	}
+
+	/**
+	 * Build Absolute Path
+	 * 
+	 * @param type $subdirectory 
+	 * @param type $file 
+	 * 
+	 * @return string
+	 */
+	protected function buildAbsolutePath($subdirectory, $file) 
+	{
+
+		//initialize
+		$absolute_path = $this->public_dir . DIRECTORY_SEPARATOR;
+		
+		//check for empty subdirectory
+		if( $subdirectory != '')
+		{
+			$absolute_path .= $subdirectory . DIRECTORY_SEPARATOR;	
+		}
+		
+		//append file
+		$absolute_path .= $this->pipeline_dir . DIRECTORY_SEPARATOR . $file;
+
+		return $absolute_path;
 	}
 
 	/**


### PR DESCRIPTION
Hi,

I needed a way to support empty subdirectories for css and js (our assets are spread across packages). Our packages are added like Assets::add('{package-name}/js/{some-file}.js'); During pipe-lining I ran into an issue that I managed to work out like this. Feel free to merge if you feel this would be useful for the package.

Thanks