### PR TITLE
Automatic timestamps for pipelines

### DIFF
--- a/API.md
+++ b/API.md
@@ -104,8 +104,10 @@ No trailing slash!.
 
 Enable assets pipeline (concatenation and minification).
 
-If you set an integer value greather than 1 it will be used
+If you set an integer value greater than 1 it will be used
 as a timestamp that will be added to the pipelined assets name.
+If you set it to -1, the pipelined assets name will be
+generated using filemtime() for each asset.
 
 * Visibility: **protected**
 

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ If your assets have changed since they were pipelined use the provided artisan c
 
 	php artisan asset:flush
 
-To deal with cache issues a custom timestamp may be appended to the pipelined assets filename by setting `pipeline` config option to an integer value greather than 1:
+To deal with cache issues a custom timestamp may be appended to the pipelined assets filename by setting `pipeline` config option to an integer value greater than 1:
 
 Example:
 
@@ -219,7 +219,10 @@ will produce:
 	<link type="text/css" rel="stylesheet" href="css/min/pipelineHash.12345.css" />
 	<script type="text/javascript" src="js/min/pipelineHash.12345.js"></script>
 
-If you happend to use NGINX with the [gzip_static](http://nginx.org/en/docs/http/ngx_http_gzip_static_module.html) feature enabled, add the following config option to automatically create a suitable gziped version of the pipelined assets:
+Alternatively, if you set the timestamp value to -1, then the modification time for
+each asset will be used to generate a pipelined assets filename that is updated automatically.
+
+If you happen to use NGINX with the [gzip_static](http://nginx.org/en/docs/http/ngx_http_gzip_static_module.html) feature enabled, add the following config option to automatically create a suitable gziped version of the pipelined assets:
 
 	'pipeline_gzip' => true,
 

--- a/src/Laravel/config.php
+++ b/src/Laravel/config.php
@@ -70,8 +70,10 @@ return array(
 
 	/**
 	 * Enable assets pipeline (concatenation and minification).
-	 * If you set an integer value greather than 1 it will be used
+	 * If you set an integer value greater than 1 it will be used
 	 * as a timestamp that will be added to the pipelined assets name.
+	 * If you set it to -1, the pipelined assets name will be
+	 * generated using filemtime() for each asset.
 	 *
 	 * @var bool|integer
 	 */

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -458,11 +458,22 @@ class Manager
 
 		// Add timestamp to extension
 		$timestamp = intval($this->pipeline);
-		if($timestamp > 1)
-			$extension = '.' . $timestamp . $extension;
+		if($timestamp > 1) {
+			// Explicit timestamp
+			$filename = md5(implode($assets)) . '.' . $timestamp . $extension;
+		} elseif($timestamp === -1) {
+			// Automatic timestamp
+			$public_dir = $this->public_dir; // PHP5.3 cannot use $this in closures
+			$filemtime = array_map(function($f) use ($public_dir) {
+				return filemtime(realpath($public_dir . DIRECTORY_SEPARATOR . $f)); // realpath() because $f may contain ".."
+			}, $assets);
+			$filename = md5(implode($assets) . implode($filemtime)) . $extension;
+		} else {
+			// No timestamp
+			$filename = md5(implode($assets)) . $extension;
+		}
 
 		// Generate paths
-		$filename = md5(implode($assets)) . $extension;
 		$relative_path = "$subdirectory/{$this->pipeline_dir}/$filename";
 		$absolute_path = realpath($pipeline_dir) . DIRECTORY_SEPARATOR . $filename;
 


### PR DESCRIPTION
The `pipeline` parameter has two options.

* `>1` - use an explicit timestamp in the pipeline assets filename
* `false` - do not use a timestamp.

I have added a third option.

* `-1` - use the modification time of each asset (using `filemtime()`) to create the asset pipeline filename.

With this option, if any asset file is updated, a new asset pipeline file will be created automatically.