### PR TITLE
Do not minify already minified files

### DIFF
--- a/src/Laravel/config.php
+++ b/src/Laravel/config.php
@@ -92,7 +92,7 @@ return array(
 	 *
 	 * @var array
 	 */
-	//'exclude_minification_regex' => '/(.min.js|-min.js)$/i';
+	//'exclude_minification_regex' => '/[-.]min\.js$/i';
 
 	/**
 	 * Enable pipelined assets compression with Gzip.

--- a/src/Laravel/config.php
+++ b/src/Laravel/config.php
@@ -92,7 +92,7 @@ return array(
 	 *
 	 * @var array
 	 */
-	//'extensions_to_exclude_minification' => ['.min.js','-min.js'];
+	//'exclude_minification_regex' => '/(.min.js|-min.js)$/i';
 
 	/**
 	 * Enable pipelined assets compression with Gzip.

--- a/src/Laravel/config.php
+++ b/src/Laravel/config.php
@@ -87,6 +87,14 @@ return array(
 	//'pipeline_dir' => 'min',
 
 	/**
+	 * Which files extensions should be excluded from minification
+	 * They will be just concatenated
+	 *
+	 * @var array
+	 */
+	//'extensions_to_exclude_minification' => ['.min.js','-min.js'];
+
+	/**
 	 * Enable pipelined assets compression with Gzip.
 	 * Use only if your webserver supports Gzip HTTP_ACCEPT_ENCODING.
 	 * Set to true to use the default compression level.
@@ -155,5 +163,4 @@ return array(
 	 * @var array
 	 */
 	//'autoload' => array('jquery-cdn'),
-
 );

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -89,7 +89,7 @@ class Manager
 	 *
 	 * @var array
 	 */
-	protected $extensions_to_exclude_minification = array('.min.js','-min.js');
+	protected $exclude_minification_regex = '/(.min.js|-min.js)$/i';
 
 	/**
 	 * Enable pipelined assets compression with Gzip. Do not enable unless you know what you are doing!.
@@ -188,7 +188,7 @@ class Manager
 				$this->$option = $config[$option];
 
 		// Set common options
-		foreach(array('public_dir', 'css_dir', 'js_dir', 'packages_dir', 'pipeline',  'pipeline_dir', 'pipeline_gzip', 'extensions_to_exclude_minification') as $option)
+		foreach(array('public_dir', 'css_dir', 'js_dir', 'packages_dir', 'pipeline',  'pipeline_dir', 'pipeline_gzip', 'exclude_minification_regex') as $option)
 			if(isset($config[$option]))
 				$this->$option = $config[$option];
 
@@ -478,7 +478,7 @@ class Manager
 		// See more: http://www.mrclay.org/2013/11/27/jsmins-classic-delimma-division-or-regexp-literal/
 		$minified = '';
 		foreach($assets as $asset){
-			if($this->stringContains($asset,$this->extensions_to_exclude_minification))
+			if(preg_match($this->exclude_minification_regex, $asset))
 			{
 				$minified .= $this->gatherLinks(array($asset));
 			}
@@ -489,7 +489,7 @@ class Manager
 
 			// Be sure no one forgets to add a ; at the end of file in js files
 			// Because we will get TypeError's
-			if($this->stringContains($extension,array('.js')))
+			if(preg_match($this->js_regex, $extension))
 				$minified .= ';' . PHP_EOL;
 		}
 
@@ -759,24 +759,5 @@ class Manager
 			$files[] = substr($file->getPathname(), $offset);
 
 		return $files;
-	}
-
-	/**
-	 * Determine if a given string contains a given substring.
-	 * laravel/framework/src/Illuminate/Support/Str.php
-	 *
-	 * @param  string  $haystack
-	 * @param  string|array  $needles
-	 * @return bool
-	 */
-	protected function stringContains($haystack, $needles)
-	{
-		foreach ((array) $needles as $needle) {
-			if ($needle != '' && strpos($haystack, $needle) !== false) {
-				return true;
-			}
-		}
-
-		return false;
 	}
 }

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -484,7 +484,7 @@ class Manager
 			}
 			else
 			{
-				$minified .= $minifier->__invoke($this->gatherLinks([$asset]));
+				$minified .= $minifier->__invoke($this->gatherLinks(array($asset)));
 			}
 
 			// Be sure no one forgets to add a ; at the end of file in js files

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -89,7 +89,7 @@ class Manager
 	 *
 	 * @var array
 	 */
-	protected $exclude_minification_regex = '/(.min.js|-min.js)$/i';
+	protected $exclude_minification_regex = '/[-.]min\.js$/i';
 
 	/**
 	 * Enable pipelined assets compression with Gzip. Do not enable unless you know what you are doing!.

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -89,7 +89,7 @@ class Manager
 	 *
 	 * @var array
 	 */
-	protected $extensions_to_exclude_minification = ['.min.js','-min.js'];
+	protected $extensions_to_exclude_minification = array('.min.js','-min.js');
 
 	/**
 	 * Enable pipelined assets compression with Gzip. Do not enable unless you know what you are doing!.
@@ -480,7 +480,7 @@ class Manager
 		foreach($assets as $asset){
 			if($this->stringContains($asset,$this->extensions_to_exclude_minification))
 			{
-				$minified .= $this->gatherLinks([$asset]);
+				$minified .= $this->gatherLinks(array($asset));
 			}
 			else
 			{

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -489,7 +489,7 @@ class Manager
 
 			// Be sure no one forgets to add a ; at the end of file in js files
 			// Because we will get TypeError's
-			if($this->stringContains($extension,['.js']))
+			if($this->stringContains($extension,array('.js')))
 				$minified .= ';' . PHP_EOL;
 		}
 

--- a/tests/AssetsManagerTest.php
+++ b/tests/AssetsManagerTest.php
@@ -162,6 +162,23 @@ class AssetsManagerTest extends PHPUnit_Framework_TestCase
 		$this->assertStringEndsWith($asset2, array_pop($assets2));
 	}
 
+	public function testCanExcludeFilesFromMinificationDefaultRegexp(){
+
+		$asset1 = 'foo.min.js';
+		$asset2 = 'foo-min.js';
+		$asset3 = 'foo.js';
+		$asset4 = 'foo.css';
+
+		//Test default Regexp
+		$pattern = PHPUnit_Framework_Assert::readAttribute($this->manager, 'exclude_minification_regex');
+
+		$this->assertEquals(1, preg_match($pattern,$asset1));
+		$this->assertEquals(1, preg_match($pattern,$asset2));
+
+		$this->assertEquals(0, preg_match($pattern,$asset3));
+		$this->assertEquals(0, preg_match($pattern,$asset4));
+	}
+
 	protected static function getMethod($name) {
 		$class = new ReflectionClass('Stolz\Assets\Manager');
 		$method = $class->getMethod($name);


### PR DESCRIPTION
Some times  JSMin will throw "Unterminated set in RegExp at byte" exception if the file is already minified. See more: http://www.mrclay.org/2013/11/27/jsmins-classic-delimma-division-or-regexp-literal/

Added possibility to exclude extensions from minification process. 