### PR TITLE
optionally add query string params to each JS and CSS asset (e.g. for cache-busting)

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -308,7 +308,7 @@ class Manager
 	 * You can implement cache-busting, etc by appending a query string value.
 	 *
 	 * @param  array|Closure $attributes
-	 * @param  array|Closure $queryArgs
+	 * @param  array $queryArgs
 	 * @return string
 	 */
 	public function css($attributes = null, $queryArgs = null)
@@ -361,7 +361,7 @@ class Manager
 	 * You can implement cache-busting, etc by appending a query string value.
 	 *
 	 * @param  array|Closure $attributes
-	 * @param  array|Closure $queryArgs
+	 * @param  array $queryArgs
 	 * @return string
 	 */
 	public function js($attributes = null, $queryArgs = null)
@@ -373,8 +373,6 @@ class Manager
 
 		if($attributes instanceof Closure)
 			return $attributes->__invoke($assets);
-		if($queryArgs instanceof Closure)
-			return $queryArgs->__invoke($assets);
 
 		// Build attributes
 		$attributes = (array) $attributes;

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -304,10 +304,14 @@ class Manager
 	 * You can take control of the tag rendering by
 	 * providing a closure that will receive an array of assets.
 	 *
+	 * Accepts an query string arguments to add to each asset.
+	 * You can implement cache-busting, etc by appending a query string value.
+	 *
 	 * @param  array|Closure $attributes
+	 * @param  array|Closure $queryArgs
 	 * @return string
 	 */
-	public function css($attributes = null)
+	public function css($attributes = null, $queryArgs = null)
 	{
 		if( ! $this->css)
 			return '';
@@ -329,10 +333,19 @@ class Manager
 
 		$attributes = $this->buildTagAttributes($attributes);
 
+		// Build query string
+		$queryArgs = (array) $queryArgs;
+		$queryString = $this->buildQueryString($queryArgs);
+
 		// Build tags
 		$output = '';
-		foreach($assets as $asset)
+		foreach($assets as $asset) {
+			// if we have a query string to add, prefix it so that we can concatenate it with the asset
+			if (!empty($queryString)) {
+				$asset .= (strpos($asset, '?') === false ? '?' : '&') . $queryString;
+			}
 			$output .= '<link href="' . $asset . '"' . $attributes . " />\n";
+		}
 
 		return $output;
 	}
@@ -344,10 +357,14 @@ class Manager
 	 * You can take control of the tag rendering by
 	 * providing a closure that will receive an array of assets.
 	 *
+	 * Accepts an query string arguments to add to each asset.
+	 * You can implement cache-busting, etc by appending a query string value.
+	 *
 	 * @param  array|Closure $attributes
+	 * @param  array|Closure $queryArgs
 	 * @return string
 	 */
-	public function js($attributes = null)
+	public function js($attributes = null, $queryArgs = null)
 	{
 		if( ! $this->js)
 			return '';
@@ -356,6 +373,8 @@ class Manager
 
 		if($attributes instanceof Closure)
 			return $attributes->__invoke($assets);
+		if($queryArgs instanceof Closure)
+			return $queryArgs->__invoke($assets);
 
 		// Build attributes
 		$attributes = (array) $attributes;
@@ -366,10 +385,19 @@ class Manager
 
 		$attributes = $this->buildTagAttributes($attributes);
 
+		// Build query string
+		$queryArgs = (array) $queryArgs;
+		$queryString = $this->buildQueryString($queryArgs);
+
 		// Build tags
 		$output = '';
-		foreach($assets as $asset)
+		foreach($assets as $asset) {
+			// if we have a query string to add, prefix it so that we can concatenate it with the asset
+			if (!empty($queryString)) {
+				$asset .= (strpos($asset, '?') === false ? '?' : '&') . $queryString;
+			}
 			$output .= '<script src="' . $asset . '"' . $attributes . "></script>\n";
+		}
 
 		return $output;
 	}
@@ -612,6 +640,24 @@ class Manager
 		}
 
 		return (count($html) > 0) ? ' ' . implode(' ', $html) : '';
+	}
+
+	/**
+	 * Build an query string from an array of query args
+	 *
+	 * @param array $queryArgs
+	 * @return string
+	 */
+	public function buildQueryString(array $queryArgs)
+	{
+		$queryStringParts = array();
+
+		foreach ($queryArgs as $key => $value)
+		{
+			$queryStringParts[] = $key . '=' . htmlentities($value, ENT_QUOTES, 'UTF-8', false);
+		}
+
+		return (count($queryStringParts) > 0) ? implode('&', $queryStringParts) : '';
 	}
 
 	/**


### PR DESCRIPTION
Needed the ability to do cache-busting for assets (i.e. to force browser to download the new version), so added the ability to add an arbitrary query string to each asset/link.

It's implemented with similar logic as used for `$attribute`, but I did not see any PHPUnit tests for `$attribute` to use as a guideline.

Let me know if you have any questions, thanks!